### PR TITLE
fix authorization by changing the order of security filters

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
 
 // This allows us to further restrict access to an endpoint inside of a controller.
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -70,6 +71,12 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
         http
             .csrf()
             .disable();
+
+        // Insert the JwtAuthenticationFilter so that it can grab credentials from the
+        // local database before they are checked for authorization
+        http
+            .addFilterBefore(authenticationTokenFilterBean(),
+                FilterSecurityInterceptor.class);
 
         // force a non-empty response body for 401's to make the response more browser friendly
         Okta.configureResourceServer401ResponseBody(http);


### PR DESCRIPTION
#### Description
JwtAuthenticationFilter.java is setup to get the authorization roles from the local database instead of looking inside the JWT token, which is the default behavior. However, it seemed to be running after the OktaAuthSecurityConfig was checking for roles, so would lock every request out, even if it should be authorized.

This just moves the filter higher up in the chain, so it runs before those roles are checked, fixing the issue.
#### Type of Change
- [X] Bug Fix